### PR TITLE
Publish Gradle Module Metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,4 @@
+<!-- do_not_remove: published-with-gradle-metadata -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -108,4 +109,30 @@
     <url>https://github.com/${gitHubRepo}</url>
     <tag>${scmTag}</tag>
   </scm>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>de.jjohannes</groupId>
+        <artifactId>gradle-module-metadata-maven-plugin</artifactId>
+        <version>0.2.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>gmm</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <platformDependencies>
+            <dependency>
+              <groupId>com.squareup.okhttp3</groupId>
+              <artifactId>okhttp-bom</artifactId>
+              <version>${okhttp3.version}</version>
+            </dependency>
+          </platformDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,18 @@
     <okio.version>2.10.0</okio.version>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp-bom</artifactId>
+        <version>${okhttp3.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <!-- Okio versions separate from okhttp and we want to pull in later versions -->
     <dependency>
@@ -43,12 +55,10 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>${okhttp3.version}</version>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>logging-interceptor</artifactId>
-      <version>${okhttp3.version}</version>
     </dependency>
     <!-- Use github-api to test that okhttp dependency not completely broken -->
     <dependency>


### PR DESCRIPTION
Hi,

Thanks for maintaining this plugin, it's an indispensable dependency.

Would you be interested in publishing [Gradle Module Metadata](https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-latest-specification.md) alongside the POM? This would make it possible for Gradle users to use these build-time opinions in resolving their own dependency graphs, while leaving the maven experience exactly the same.

### Why?
This would be a step forward because I know I want to use `mockwebserver` in tests, but my only opinion about the version is "use the one that works with this version of okhttp." The `okhttp-bom` is an existing publication that has this version information.

### Examples

#### Without Gradle Module Metadata
If I create a `build.gradle` that consumes okhttp-api's latest release, dependency resolution fails.

<details>
  <summary><code>build.gradle</code></summary>

```gradle
plugins { id 'java' }
repositories { maven { url 'https://repo.jenkins-ci.org/public' } }

dependencies {
  implementation 'io.jenkins.plugins:okhttp-api:4.9.2-20211102'
  testImplementation 'com.squareup.okhttp3:mockwebserver'
}
```
</details>

<details>
  <summary><code>$ ./gradlew --quiet dependencies --configuration testCompileClasspath</code></summary>

```
------------------------------------------------------------
Root project 'consumer-example'
------------------------------------------------------------

testCompileClasspath - Compile classpath for source set 'test'.
+--- io.jenkins.plugins:okhttp-api:4.9.2-20211102
|    +--- com.squareup.okio:okio:2.10.0
|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.4.20
|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.4.20
|    |    |    \--- org.jetbrains:annotations:13.0
|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.4.20
|    +--- com.squareup.okhttp3:okhttp:4.9.2
|    |    +--- com.squareup.okio:okio:2.8.0 -> 2.10.0 (*)
|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.10 -> 1.4.20 (*)
|    \--- com.squareup.okhttp3:logging-interceptor:4.9.2
|         +--- com.squareup.okhttp3:okhttp:4.9.2 (*)
|         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.10
|              +--- org.jetbrains.kotlin:kotlin-stdlib:1.4.10 -> 1.4.20 (*)
|              \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.10
|                   \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.10 -> 1.4.20 (*)
\--- com.squareup.okhttp3:mockwebserver FAILED
```
</details>

To get around this, I need to specify a version. Back in the okhttp-api:3.x days, I defined my dependency like this:

```gradle
testImplementation 'com.squareup.okhttp3:mockwebserver:3.+'
```

This worked, but when 4.x was released I started getting failures for a missing class from `mockwebserver`. Turns out I needed to go bump this version to `4.+`, or implement a [Component Metadata Rule](https://docs.gradle.org/current/userguide/component_metadata_rules.html).

#### With Gradle Module Metadata
To test this out, I ran `mvn clean install` with these changes and updated my `build.gradle` to include `mavenLocal`.

<details>
  <summary><code>build.gradle</code></summary>

```gradle
plugins { id 'java' }

repositories {
  mavenLocal { // so I can resolve the snapshot installed with mvn clean install
    metadataSources {
      gradleMetadata()
      mavenPom()
    }
  }
  maven { url 'https://repo.jenkins-ci.org/public' }
}

dependencies {
  implementation 'io.jenkins.plugins:okhttp-api:4.9.2-20211103-SNAPSHOT' // locally published version
  testImplementation 'com.squareup.okhttp3:mockwebserver'
}
```
</details>

Now Gradle is able to resolve `mockwebserver` at the correct version with no extra config!

<details>
  <summary><code>$ ./gradlew --quiet dependencies --configuration testCompileClasspath</code></summary>

```
------------------------------------------------------------
Root project 'consumer-example'
------------------------------------------------------------

testCompileClasspath - Compile classpath for source set 'test'.
+--- io.jenkins.plugins:okhttp-api:4.9.2-20211103-SNAPSHOT
|    +--- com.squareup.okio:okio:2.10.0
|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.4.20
|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.4.20
|    |    |    \--- org.jetbrains:annotations:13.0
|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.4.20
|    +--- com.squareup.okhttp3:okhttp:4.9.2
|    |    +--- com.squareup.okio:okio:2.8.0 -> 2.10.0 (*)
|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.10 -> 1.4.20 (*)
|    +--- com.squareup.okhttp3:logging-interceptor:4.9.2
|    |    +--- com.squareup.okhttp3:okhttp:4.9.2 (*)
|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.10
|    |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.4.10 -> 1.4.20 (*)
|    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.10
|    |              \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.10 -> 1.4.20 (*)
|    \--- com.squareup.okhttp3:okhttp-bom:4.9.2
|         +--- com.squareup.okhttp3:mockwebserver:4.9.2 (c)
|         +--- com.squareup.okhttp3:okhttp:4.9.2 (c)
|         \--- com.squareup.okhttp3:logging-interceptor:4.9.2 (c)
\--- com.squareup.okhttp3:mockwebserver -> 4.9.2
     +--- com.squareup.okhttp3:okhttp:4.9.2 (*)
     +--- junit:junit:4.13
     |    \--- org.hamcrest:hamcrest-core:1.3
     \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.10 (*)
```
</details>

### Notes

* The `<dependencyManagement>` section isn't strictly required and I can revert if needed, but I thought it was worth building with what we end up recommending rather than specifying the okhttp version on each dependency individually.
* This implementation relies on [jjohannes/gradle-module-metadata-maven-plugin](https://github.com/jjohannes/gradle-module-metadata-maven-plugin).

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
