### PR TITLE
Upgrade gradle-module-metadata-plugin to 0.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
       <plugin>
         <groupId>de.jjohannes</groupId>
         <artifactId>gradle-module-metadata-maven-plugin</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
This fixes an issue in the generated Gradle Module Metadata where the associated plugin archive is missing a version in the filename.

See also jjohannes/gradle-module-metadata-maven-plugin#10.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
