### PR TITLE
Improve the proxy authenticator

### DIFF
--- a/src/main/java/io/jenkins/plugins/okhttp/api/internals/JenkinsProxyAuthenticator.java
+++ b/src/main/java/io/jenkins/plugins/okhttp/api/internals/JenkinsProxyAuthenticator.java
@@ -52,15 +52,6 @@ public class JenkinsProxyAuthenticator implements Authenticator {
 
     private boolean isAuthenticationSchemeSupported(@NonNull final String proxyAuthenticateHeader) {
         final String lowerCaseHeader = proxyAuthenticateHeader.toLowerCase(Locale.ROOT);
-
-        /* According https://square.github.io/okhttp/4.x/okhttp/okhttp3/-authenticator/ :
-
-             | OkHttp will call authenticate with a fake HTTP/1.1 407 Proxy Authentication Required response that has a
-             | Proxy-Authenticate: OkHttp-Preemptive challenge. The proxy authenticator may return either an
-             | authenticated request, or null to connect without authentication.
-
-           That is why we check for the OkHttp-Preemptive header.
-         */
-        return lowerCaseHeader.startsWith("basic") || lowerCaseHeader.equals("okhttp-preemptive");
+        return lowerCaseHeader.startsWith("basic");
     }
 }

--- a/src/main/java/io/jenkins/plugins/okhttp/api/internals/JenkinsProxyAuthenticator.java
+++ b/src/main/java/io/jenkins/plugins/okhttp/api/internals/JenkinsProxyAuthenticator.java
@@ -14,6 +14,7 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.io.IOException;
+import java.util.Locale;
 import java.util.logging.Logger;
 
 @Restricted(NoExternalUse.class)
@@ -50,7 +51,7 @@ public class JenkinsProxyAuthenticator implements Authenticator {
     }
 
     private boolean isAuthenticationSchemeSupported(@NonNull final String proxyAuthenticateHeader) {
-        final String lowerCaseHeader = proxyAuthenticateHeader.toLowerCase();
+        final String lowerCaseHeader = proxyAuthenticateHeader.toLowerCase(Locale.ROOT);
 
         /* According https://square.github.io/okhttp/4.x/okhttp/okhttp3/-authenticator/ :
 
@@ -60,6 +61,6 @@ public class JenkinsProxyAuthenticator implements Authenticator {
 
            That is why we check for the OkHttp-Preemptive header.
          */
-        return lowerCaseHeader.startsWith("basic") || lowerCaseHeader.equalsIgnoreCase("okhttp-preemptive");
+        return lowerCaseHeader.startsWith("basic") || lowerCaseHeader.equals("okhttp-preemptive");
     }
 }

--- a/src/main/java/io/jenkins/plugins/okhttp/api/internals/JenkinsProxyAuthenticator.java
+++ b/src/main/java/io/jenkins/plugins/okhttp/api/internals/JenkinsProxyAuthenticator.java
@@ -51,7 +51,6 @@ public class JenkinsProxyAuthenticator implements Authenticator {
     }
 
     private boolean isAuthenticationSchemeSupported(@NonNull final String proxyAuthenticateHeader) {
-        final String lowerCaseHeader = proxyAuthenticateHeader.toLowerCase(Locale.ROOT);
-        return lowerCaseHeader.startsWith("basic");
+        return proxyAuthenticateHeader.toLowerCase(Locale.ROOT).startsWith("basic");
     }
 }

--- a/src/test/java/jenkins/plugins/okhttp/api/ClientTest.java
+++ b/src/test/java/jenkins/plugins/okhttp/api/ClientTest.java
@@ -171,8 +171,7 @@ public class ClientTest {
         secureProxy("Basic realm=\"somerealm\"", "proxy-user:proxy-pass");
         server.stubFor(WireMock.get("/hello").willReturn(aResponse().proxiedFrom(proxy.baseUrl())));
 
-        final OkHttpClient client = JenkinsOkHttpClient.newClientBuilder(new OkHttpClient())
-                .build();
+        final OkHttpClient client = JenkinsOkHttpClient.newClientBuilder(new OkHttpClient()).build();
         final Request request = new Request.Builder().get().url(server.url("/hello")).build();
 
         final Response response = new OkHttpFuture<>(client.newCall(request), OkHttpFuture.GET_RESPONSE).get();
@@ -189,8 +188,7 @@ public class ClientTest {
         secureProxy("OkHttp-Preemptive", "proxy-user:proxy-pass");
         server.stubFor(WireMock.get("/hello").willReturn(aResponse().proxiedFrom(proxy.baseUrl())));
 
-        final OkHttpClient client = JenkinsOkHttpClient.newClientBuilder(new OkHttpClient())
-                .build();
+        final OkHttpClient client = JenkinsOkHttpClient.newClientBuilder(new OkHttpClient()).build();
         final Request request = new Request.Builder().get().url(server.url("/hello")).build();
 
         final Response response = new OkHttpFuture<>(client.newCall(request), OkHttpFuture.GET_RESPONSE).get();

--- a/src/test/java/jenkins/plugins/okhttp/api/ClientTest.java
+++ b/src/test/java/jenkins/plugins/okhttp/api/ClientTest.java
@@ -183,23 +183,6 @@ public class ClientTest {
     }
 
     @Test
-    public void testProxyWithPreemptiveAuth() throws ExecutionException, InterruptedException, IOException {
-        jenkinsRule.jenkins.setProxy(new ProxyConfiguration("127.0.0.1", proxy.port(), "proxy-user", "proxy-pass"));
-        secureProxy("OkHttp-Preemptive", "proxy-user:proxy-pass");
-        server.stubFor(WireMock.get("/hello").willReturn(aResponse().proxiedFrom(proxy.baseUrl())));
-
-        final OkHttpClient client = JenkinsOkHttpClient.newClientBuilder(new OkHttpClient()).build();
-        final Request request = new Request.Builder().get().url(server.url("/hello")).build();
-
-        final Response response = new OkHttpFuture<>(client.newCall(request), OkHttpFuture.GET_RESPONSE).get();
-
-        assertEquals(200, response.code());
-        try (final ResponseBody body = response.body()) {
-            assertEquals("Hello from proxy", body.string());
-        }
-    }
-
-    @Test
     public void testProxySelector() throws URISyntaxException {
         final String noProxyHosts = new StringJoiner("|")
                 .add("1.2.3.4")


### PR DESCRIPTION
Signed-off-by: Thierry Wasylczenko <thierry.wasylczenko@gmail.com>

<!-- Please describe your pull request here. -->

Until now, the `JenkinsProxyAuthenticator` checked the authentication scheme in a case sensitive way. This check has been updated to ignore the case.

Moreover, it seems OkHttp always tries to send an authentication request using the `Proxy-Authenticate: OkHttp-Preemptive` prior to any `CONNECT` request. According the [documentation](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-authenticator/)

> Prior to sending any CONNECT request OkHttp always calls the proxy authenticator so that it may prepare preemptive authentication. OkHttp will call [authenticate](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-authenticator/authenticate/) with a fake HTTP/1.1 407 Proxy Authentication Required response that has a Proxy-Authenticate: OkHttp-Preemptive challenge. The proxy authenticator may return either an authenticated request, or null to connect without authentication.

This is why the authentication scheme also checks for this header as well. 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
