### PR TITLE
Bump okio to 3.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,6 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>logging-interceptor</artifactId>
-      <version>5.0.0-alpha.11</version>
     </dependency>
     <!-- Use github-api to test that okhttp dependency not completely broken -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <jenkins.version>2.289.1</jenkins.version>
     <no-test-jar>false</no-test-jar>
-    <okio.version>2.10.0</okio.version>
+    <okio.version>3.3.0</okio.version>
   </properties>
 
   <dependencyManagement>
@@ -45,6 +45,11 @@
   </dependencyManagement>
 
   <dependencies>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-jdk8</artifactId>
+      <version>1.8.10</version>
+    </dependency>
     <!-- Okio versions separate from okhttp and we want to pull in later versions -->
     <dependency>
       <groupId>com.squareup.okio</groupId>
@@ -58,6 +63,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>logging-interceptor</artifactId>
+      <version>5.0.0-alpha.11</version>
     </dependency>
     <!-- Use github-api to test that okhttp dependency not completely broken -->
     <dependency>


### PR DESCRIPTION
Bump `okio` to `3.3.0` in order to have the latest version of `kotlin` and address the vulnerability in `kotlin-stdlib` as it was discovered by security scan false positives on existing dependencies

I also had to override the dependencies for `kotlin-stdlib-jdk8` and `logging-interceptor` otherwise it would retrieve old dependencies and `okhttp-api` would not build

I have tested the modifications: I built `okhttp-api` with the newer versions, and `okhttp-api.hpi` contains `kotlin-1.8.10`

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
