### PR TITLE
declare used transitive deps whose version we manage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,10 @@
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <jenkins.version>2.361.4</jenkins.version>
     <no-test-jar>false</no-test-jar>
+    <!-- 
+      beware https://github.com/jenkinsci/plugin-pom/issues/705 and https://github.com/jenkinsci/plugin-pom/issues/707
+      if updating these ensure the used transitive deps that have their version managed are updated as direct dependencies and any unused ones are removed.
+    -->
     <okio.version>3.3.0</okio.version>
     <kotlin.version>1.8.10</kotlin.version>
   </properties>
@@ -99,6 +103,34 @@
       <version>2.35.0</version>
       <scope>test</scope>
     </dependency>
+
+    <!-- inline used transitive okhttp dependencies -->
+    <!-- no extra transitive deps used -->
+    <!-- inline used transitive okio dependencies -->
+    <!-- com.squareup.okio:okio-jvm is a transitive dep but does not have its version managed -->
+    <!-- inline used transitive kotlin dependencies -->
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>13.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-jdk8</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-jdk7</artifactId>
+    </dependency>
+
   </dependencies>
 
   <!-- get every artifact through maven.glassfish.org, which proxies all the artifacts that we need -->


### PR DESCRIPTION
Due to https://github.com/jenkinsci/plugin-pom/issues/705 and https://issues.apache.org/jira/browse/MNG-7003 using dependencyManagement to manage the transitive dependencies is not a good idea if you are going to be consumed by something else.

this keeps the dependencyManagement so we can manage the verions as one, but where we use a transitive dependency that has had its version managed we inline it into the dependencies

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
