### PR TITLE
remove org.jetbrains:annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,11 +110,6 @@
     <!-- com.squareup.okio:okio-jvm is a transitive dep but does not have its version managed -->
     <!-- inline used transitive kotlin dependencies -->
     <dependency>
-      <groupId>org.jetbrains</groupId>
-      <artifactId>annotations</artifactId>
-      <version>13.0</version>
-    </dependency>
-    <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
     </dependency>
@@ -125,6 +120,12 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jetbrains</groupId>
+          <artifactId>annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>


### PR DESCRIPTION
The annotations are all SOURCE or CLASS retention never RUNTIME https://github.com/JetBrains/java-annotations/blob/master/CONTRIBUTING.md#retention-policy

as such they are not needed in runtime and not bundling them makes it slightly nicer for consumers as they won;t accidently pick them up and also will not have to manage upperBounds conflicts if they also use config-as-code

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
