### PR TITLE
EOL JSR 305

### DIFF
--- a/src/test/java/jenkins/plugins/github/api/SmokeTest.java
+++ b/src/test/java/jenkins/plugins/github/api/SmokeTest.java
@@ -20,7 +20,7 @@ import org.kohsuke.github.GitHubBuilder;
 import org.kohsuke.github.HttpConnector;
 import org.kohsuke.github.extras.okhttp3.OkHttpConnector;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
@@ -41,7 +41,7 @@ public class SmokeTest {
         GitHub apply(MockGitHub t) throws IOException;
     }
 
-    @Nonnull
+    @NonNull
     IOFunction connectFunction;
 
     public SmokeTest(IOFunction connectFunction) {


### PR DESCRIPTION
Several years ago, Jenkins core switched from the abandoned JSR 305 annotations to SpotBugs annotations, but this plugin never caught up. This PR adapts this plugin to the common convention used in Jenkins core and the vast majority of other Jenkins plugins.