### PR TITLE
[JENKINS-70163] Do not cache resolved address in ProxySelector

### DIFF
--- a/src/main/java/io/jenkins/plugins/okhttp/api/JenkinsOkHttpClient.java
+++ b/src/main/java/io/jenkins/plugins/okhttp/api/JenkinsOkHttpClient.java
@@ -1,12 +1,9 @@
 package io.jenkins.plugins.okhttp.api;
 
-import hudson.ProxyConfiguration;
 import io.jenkins.plugins.okhttp.api.internals.JenkinsProxyAuthenticator;
 import io.jenkins.plugins.okhttp.api.internals.JenkinsProxySelector;
 import jenkins.model.Jenkins;
 import okhttp3.OkHttpClient;
-
-import java.net.Proxy;
 
 /**
  * This class allows to take into consideration if Jenkins is running behind a proxy or not and return a proper {@link OkHttpClient}
@@ -25,17 +22,8 @@ public class JenkinsOkHttpClient {
      */
     public static OkHttpClient.Builder newClientBuilder(OkHttpClient httpClient) {
         OkHttpClient.Builder reBuild = httpClient.newBuilder();
-        if (Jenkins.get().proxy != null) {
-            final ProxyConfiguration proxy = Jenkins.get().proxy;
-
-            if (proxy.getUserName() != null) {
-                reBuild.proxyAuthenticator(new JenkinsProxyAuthenticator(proxy));
-            }
-            reBuild.proxySelector(new JenkinsProxySelector(proxy));
-        } else {
-            reBuild.proxy(Proxy.NO_PROXY);
-        }
-
+        reBuild.proxyAuthenticator(new JenkinsProxyAuthenticator());
+        reBuild.proxySelector(new JenkinsProxySelector());
         return reBuild;
     }
 }

--- a/src/main/java/io/jenkins/plugins/okhttp/api/internals/JenkinsProxyAuthenticator.java
+++ b/src/main/java/io/jenkins/plugins/okhttp/api/internals/JenkinsProxyAuthenticator.java
@@ -5,6 +5,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.ProxyConfiguration;
 import hudson.util.Secret;
+import jenkins.model.Jenkins;
 import okhttp3.Authenticator;
 import okhttp3.Credentials;
 import okhttp3.Request;
@@ -20,16 +21,17 @@ import java.util.logging.Logger;
 @Restricted(NoExternalUse.class)
 public class JenkinsProxyAuthenticator implements Authenticator {
     private static final Logger LOGGER = Logger.getLogger(JenkinsProxyAuthenticator.class.getName());
-    private final ProxyConfiguration proxy;
-
-    public JenkinsProxyAuthenticator(final ProxyConfiguration proxy) {
-        this.proxy = proxy;
-    }
 
     @Nullable
     @Override
     @SuppressFBWarnings(value = "NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION", justification = "Prefer SpotBugs @Nullable")
     public Request authenticate(@Nullable Route route, Response response) throws IOException {
+
+        ProxyConfiguration proxy = Jenkins.get().proxy;
+        if (proxy == null || proxy.getUserName() == null) {
+            return null;
+        }
+
         if (response.request().header("Proxy-Authorization") != null) {
             // If the header is not null, it means an authentication attempt failed. So giving up
             return null;
@@ -38,10 +40,11 @@ public class JenkinsProxyAuthenticator implements Authenticator {
         final String proxyAuthenticateHeader = response.header("Proxy-Authenticate");
         if (proxyAuthenticateHeader != null) {
             if (isAuthenticationSchemeSupported(proxyAuthenticateHeader)) {
+
                 final String credential = Credentials.basic(proxy.getUserName(), Secret.toString(proxy.getSecretPassword()));
                 return response.request().newBuilder()
-                        .header("Proxy-Authorization", credential)
-                        .build();
+                    .header("Proxy-Authorization", credential)
+                    .build();
             } else {
                 LOGGER.warning("The proxy authentication scheme is not supported: " + proxyAuthenticateHeader);
             }

--- a/src/main/java/io/jenkins/plugins/okhttp/api/internals/JenkinsProxyAuthenticator.java
+++ b/src/main/java/io/jenkins/plugins/okhttp/api/internals/JenkinsProxyAuthenticator.java
@@ -27,7 +27,7 @@ public class JenkinsProxyAuthenticator implements Authenticator {
     @SuppressFBWarnings(value = "NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION", justification = "Prefer SpotBugs @Nullable")
     public Request authenticate(@Nullable Route route, Response response) throws IOException {
 
-        ProxyConfiguration proxy = Jenkins.get().proxy;
+        ProxyConfiguration proxy = Jenkins.get().getProxy();
         if (proxy == null || proxy.getUserName() == null) {
             return null;
         }

--- a/src/main/java/io/jenkins/plugins/okhttp/api/internals/JenkinsProxySelector.java
+++ b/src/main/java/io/jenkins/plugins/okhttp/api/internals/JenkinsProxySelector.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.okhttp.api.internals;
 
 import hudson.ProxyConfiguration;
+import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -10,7 +11,6 @@ import java.net.Proxy;
 import java.net.ProxySelector;
 import java.net.SocketAddress;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
@@ -20,23 +20,23 @@ import java.util.regex.Pattern;
 @Restricted(NoExternalUse.class)
 public class JenkinsProxySelector extends ProxySelector {
     private static final Logger LOGGER = Logger.getLogger(JenkinsProxySelector.class.getName());
-    private final ProxyConfiguration configuration;
-    private final Proxy proxy;
-
-    public JenkinsProxySelector(final ProxyConfiguration configuration) {
-        this.configuration = configuration;
-        this.proxy = new Proxy(Proxy.Type.HTTP, InetSocketAddress.createUnresolved(configuration.name, configuration.port));
-    }
 
     @Override
     public List<Proxy> select(URI uri) {
+
+        ProxyConfiguration configuration = Jenkins.get().proxy;
+        if (configuration == null) {
+            return Collections.singletonList(Proxy.NO_PROXY);
+        }
+
         final String host = uri.getHost();
         for (Pattern p : configuration.getNoProxyHostPatterns()) {
             if (p.matcher(host).matches()) {
                 return Collections.singletonList(Proxy.NO_PROXY);
             }
         }
-        return Collections.singletonList(proxy);
+        return Collections.singletonList(new Proxy(Proxy.Type.HTTP,
+            new InetSocketAddress(configuration.name, configuration.port)));
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/okhttp/api/internals/JenkinsProxySelector.java
+++ b/src/main/java/io/jenkins/plugins/okhttp/api/internals/JenkinsProxySelector.java
@@ -25,7 +25,7 @@ public class JenkinsProxySelector extends ProxySelector {
 
     public JenkinsProxySelector(final ProxyConfiguration configuration) {
         this.configuration = configuration;
-        this.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(configuration.name, configuration.port));
+        this.proxy = new Proxy(Proxy.Type.HTTP, InetSocketAddress.createUnresolved(configuration.name, configuration.port));
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/okhttp/api/internals/JenkinsProxySelector.java
+++ b/src/main/java/io/jenkins/plugins/okhttp/api/internals/JenkinsProxySelector.java
@@ -6,7 +6,6 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.ProxySelector;
 import java.net.SocketAddress;
@@ -15,7 +14,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Pattern;
 
 @Restricted(NoExternalUse.class)
 public class JenkinsProxySelector extends ProxySelector {
@@ -24,19 +22,11 @@ public class JenkinsProxySelector extends ProxySelector {
     @Override
     public List<Proxy> select(URI uri) {
 
-        ProxyConfiguration configuration = Jenkins.get().proxy;
+        ProxyConfiguration configuration = Jenkins.get().getProxy();
         if (configuration == null) {
             return Collections.singletonList(Proxy.NO_PROXY);
         }
-
-        final String host = uri.getHost();
-        for (Pattern p : configuration.getNoProxyHostPatterns()) {
-            if (p.matcher(host).matches()) {
-                return Collections.singletonList(Proxy.NO_PROXY);
-            }
-        }
-        return Collections.singletonList(new Proxy(Proxy.Type.HTTP,
-            new InetSocketAddress(configuration.name, configuration.port)));
+        return List.of(configuration.createProxy(uri.getHost()));
     }
 
     @Override

--- a/src/test/java/jenkins/plugins/okhttp/api/ClientTest.java
+++ b/src/test/java/jenkins/plugins/okhttp/api/ClientTest.java
@@ -190,8 +190,8 @@ public class ClientTest {
                 .add("my*.super-jenkins.io")
                 .toString();
 
-        final ProxyConfiguration configuration = new ProxyConfiguration("127.0.0.1", proxy.port(), null, null, noProxyHosts);
-        final JenkinsProxySelector proxySelector = new JenkinsProxySelector(configuration);
+        jenkinsRule.jenkins.setProxy(new ProxyConfiguration("127.0.0.1", proxy.port(), null, null, noProxyHosts));
+        final JenkinsProxySelector proxySelector = new JenkinsProxySelector();
 
         final URI[] urisThatShouldNotUseProxy = {
                 new URI("http://1.2.3.4"),


### PR DESCRIPTION
[JENKINS-70163](https://issues.jenkins.io/browse/JENKINS-70163): `InetSocketAddress` caches the resolved address which is a problem in environment where network may change (if redeploying a proxy that result in a different resolved IP).

See also https://github.com/square/okhttp/issues/7698.

### Testing done

* Setup Jenkins with a proxy
* Create a GitHub Multibranch Pipeline
* Start the branch indexing
* Redeploy the proxy so that the proxy host resolve to a different IP (I run things in kubernetes, and way to replicate this is to scale down and up a proxy deployment and then remove / recreate the proxy service, the service hostname is the same but the IPs of the pod and service have changed)
* Start Branch Indexing again

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue