### PR TITLE
Refresh plugin for August 2023

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.66</version>
+    <version>4.71</version>
     <relativePath />
   </parent>
   
@@ -28,7 +28,7 @@
     <revision>4.11.0</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.387.3</jenkins.version>
     <no-test-jar>false</no-test-jar>
     <!-- 
       beware https://github.com/jenkinsci/plugin-pom/issues/705 and https://github.com/jenkinsci/plugin-pom/issues/707
@@ -86,10 +86,6 @@
       <scope>test</scope>
       <exclusions>
         <!-- Provided by Jenkins -->
-        <exclusion>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-lang3</artifactId>
-        </exclusion>
         <exclusion>
           <groupId>commons-io</groupId>
           <artifactId>commons-io</artifactId>


### PR DESCRIPTION
Adapting to https://github.com/jenkinsci/jenkins-test-harness/issues/550. Commons Lang 3 was never provided by core, but it was (accidentally) provided by JTH prior to https://github.com/jenkinsci/jenkins-test-harness/issues/550.

If merged, please release this to unblock some PCT work I am trying to do.