### PR TITLE
backport pull request #81 to okhttp-api-4.9.2-20211102

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <url>https://github.com/jenkinsci/okhttp-api-plugin</url>
 
   <properties>
-    <revision>4.9.2-20211103</revision>
+    <revision>4.9.2.1-20230828</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <jenkins.version>2.222.4</jenkins.version>

--- a/src/main/java/io/jenkins/plugins/okhttp/api/internals/JenkinsProxyAuthenticator.java
+++ b/src/main/java/io/jenkins/plugins/okhttp/api/internals/JenkinsProxyAuthenticator.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.okhttp.api.internals;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.ProxyConfiguration;
@@ -13,6 +14,7 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.io.IOException;
+import java.util.Locale;
 import java.util.logging.Logger;
 
 @Restricted(NoExternalUse.class)
@@ -35,7 +37,7 @@ public class JenkinsProxyAuthenticator implements Authenticator {
 
         final String proxyAuthenticateHeader = response.header("Proxy-Authenticate");
         if (proxyAuthenticateHeader != null) {
-            if (proxyAuthenticateHeader.startsWith("Basic")) {
+            if (isAuthenticationSchemeSupported(proxyAuthenticateHeader)) {
                 final String credential = Credentials.basic(proxy.getUserName(), Secret.toString(proxy.getSecretPassword()));
                 return response.request().newBuilder()
                         .header("Proxy-Authorization", credential)
@@ -46,5 +48,9 @@ public class JenkinsProxyAuthenticator implements Authenticator {
         }
 
         return null;
+    }
+
+    private boolean isAuthenticationSchemeSupported(@NonNull final String proxyAuthenticateHeader) {
+        return proxyAuthenticateHeader.toLowerCase(Locale.ROOT).startsWith("basic");
     }
 }

--- a/src/test/java/jenkins/plugins/okhttp/api/ClientTest.java
+++ b/src/test/java/jenkins/plugins/okhttp/api/ClientTest.java
@@ -1,6 +1,5 @@
 package jenkins.plugins.okhttp.api;
 
-import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import hudson.ProxyConfiguration;
@@ -63,12 +62,14 @@ public class ClientTest {
                         .withStatus(407) // 407: Proxy Authentication Required
                         .withHeader("Proxy-Authenticate", authenticationType)));
 
-        if (authorizedUserPass != null && "Basic".equals(authenticationType)) {
-            for (String userPass : authorizedUserPass) {
-                final String authenticationHeaderValue = "Basic " + Base64.getEncoder().encodeToString(userPass.getBytes(StandardCharsets.UTF_8));
-                proxy.stubFor(get(WireMock.anyUrl())
-                        .withHeader("Proxy-Authorization", WireMock.equalTo(authenticationHeaderValue))
-                        .willReturn(WireMock.ok("Hello from proxy")));
+        if (authorizedUserPass != null && authenticationType != null) {
+            if (authenticationType.toLowerCase().contains("basic") || authenticationType.equalsIgnoreCase("okhttp-preemptive")) {
+                for (String userPass : authorizedUserPass) {
+                    final String authenticationHeaderValue = "Basic " + Base64.getEncoder().encodeToString(userPass.getBytes(StandardCharsets.UTF_8));
+                    proxy.stubFor(get(WireMock.anyUrl())
+                            .withHeader("Proxy-Authorization", WireMock.equalTo(authenticationHeaderValue))
+                            .willReturn(WireMock.ok("Hello from proxy")));
+                }
             }
         }
     }
@@ -154,6 +155,23 @@ public class ClientTest {
 
         final OkHttpClient client = JenkinsOkHttpClient.newClientBuilder(new OkHttpClient())
                 .build();
+        final Request request = new Request.Builder().get().url(server.url("/hello")).build();
+
+        final Response response = new OkHttpFuture<>(client.newCall(request), OkHttpFuture.GET_RESPONSE).get();
+
+        assertEquals(200, response.code());
+        try (final ResponseBody body = response.body()) {
+            assertEquals("Hello from proxy", body.string());
+        }
+    }
+
+    @Test
+    public void testProxyWithBasicAuthAndRealm() throws ExecutionException, InterruptedException, IOException {
+        jenkinsRule.jenkins.setProxy(new ProxyConfiguration("127.0.0.1", proxy.port(), "proxy-user", "proxy-pass"));
+        secureProxy("Basic realm=\"somerealm\"", "proxy-user:proxy-pass");
+        server.stubFor(WireMock.get("/hello").willReturn(aResponse().proxiedFrom(proxy.baseUrl())));
+
+        final OkHttpClient client = JenkinsOkHttpClient.newClientBuilder(new OkHttpClient()).build();
         final Request request = new Request.Builder().get().url(server.url("/hello")).build();
 
         final Response response = new OkHttpFuture<>(client.newCall(request), OkHttpFuture.GET_RESPONSE).get();


### PR DESCRIPTION
Merge pull request #81 from twasyl/improve-proxy-authenticator Improve the proxy authenticator

(cherry picked from commit f786fdfa22c0a7915e6f07c7da0e7869a37ff242)

Draft PR to create an incremental build for backporting https://github.com/jenkinsci/okhttp-api-plugin/pull/81 on top of https://github.com/jenkinsci/okhttp-api-plugin/tree/okhttp-api-4.9.2-20211102