### PR TITLE
[JENKINS-73315] Adapt OkHttp API for Jetty 12 (EE 9)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <revision>4.11.0</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.472</jenkins.version>
+    <jenkins.version>2.475</jenkins.version>
     <no-test-jar>false</no-test-jar>
     <!-- 
       beware https://github.com/jenkinsci/plugin-pom/issues/705 and https://github.com/jenkinsci/plugin-pom/issues/707
@@ -36,9 +36,9 @@
     -->
     <okio.version>3.5.0</okio.version>
     <kotlin.version>1.9.22</kotlin.version>
-    <!--TODO Until is included in parent pom -->
+    <!-- TODO JENKINS-73339 until in parent POM -->
+    <jenkins-test-harness.version>2265.v3da_49c8134d6</jenkins-test-harness.version>
     <maven.compiler.release>17</maven.compiler.release>
-    <jenkins-test-harness.version>2250.v03a_1295b_0a_30</jenkins-test-harness.version>
   </properties>
 
   <dependencyManagement>
@@ -63,6 +63,12 @@
         <version>${kotlin.version}</version>
         <scope>import</scope>
         <type>pom</type>
+      </dependency>
+      <!-- TODO JENKINS-73339 until in parent POM, work around https://github.com/jenkinsci/plugin-pom/issues/936 -->
+      <dependency>
+        <groupId>jakarta.servlet</groupId>
+        <artifactId>jakarta.servlet-api</artifactId>
+        <version>5.0.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/test/java/jenkins/plugins/github/api/mock/MockGitHub.java
+++ b/src/test/java/jenkins/plugins/github/api/mock/MockGitHub.java
@@ -22,18 +22,18 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import javax.servlet.ServletException;
+import jakarta.servlet.ServletException;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.ee8.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
 import org.jvnet.hudson.test.ThreadPoolImpl;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
 public class MockGitHub implements Closeable {
     private AtomicLong nextId = new AtomicLong();
@@ -178,7 +178,7 @@ public class MockGitHub implements Closeable {
     public HttpResponse doRepositories(final @QueryParameter long since) {
         return new HttpResponse() {
             @Override
-            public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node)
+            public void generateResponse(StaplerRequest2 req, StaplerResponse2 rsp, Object node)
                     throws IOException, ServletException {
                 List<MockRepository> repositories = new ArrayList<>();
                 for (MockOwner<?> o : owners()) {


### PR DESCRIPTION
See [JENKINS-73315](https://issues.jenkins.io/browse/JENKINS-73315).