### PR TITLE
[JENKINS-73140] Adapt to Jetty 12 EE8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,5 +2,5 @@ buildPlugin(
   useContainerAgent: true,
   configurations: [
     [platform: 'linux', jdk: 21],
-    [platform: 'windows', jdk: 17],
+    [platform: 'windows', jdk: 17]
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,6 @@
 buildPlugin(
   useContainerAgent: true,
   configurations: [
-    [platform: 'linux', jdk: 11],
     [platform: 'linux', jdk: 21],
     [platform: 'windows', jdk: 17],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <revision>4.11.0</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.387.3</jenkins.version>
+    <jenkins.version>2.472</jenkins.version>
     <no-test-jar>false</no-test-jar>
     <!-- 
       beware https://github.com/jenkinsci/plugin-pom/issues/705 and https://github.com/jenkinsci/plugin-pom/issues/707
@@ -36,6 +36,9 @@
     -->
     <okio.version>3.5.0</okio.version>
     <kotlin.version>1.9.22</kotlin.version>
+    <!--TODO Until is included in parent pom -->
+    <maven.compiler.release>17</maven.compiler.release>
+    <jenkins-test-harness.version>2250.v03a_1295b_0a_30</jenkins-test-harness.version>
   </properties>
 
   <dependencyManagement>

--- a/src/test/java/jenkins/plugins/github/api/mock/MockGitHub.java
+++ b/src/test/java/jenkins/plugins/github/api/mock/MockGitHub.java
@@ -27,7 +27,7 @@ import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee8.servlet.ServletContextHandler;
 import org.jvnet.hudson.test.ThreadPoolImpl;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.QueryParameter;


### PR DESCRIPTION
Adapt the plugin to Jetty 12 EE8 so it can work with core 2.472+ versions. See https://issues.jenkins.io/browse/JENKINS-73130

Closes #204 

### Testing done
Running locally and in the pr builder against `2.472-rc35224.f615612a_1850` as `2.472` has not yet been released

This is expected to fail in PR builder until `2.472` is released


### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
